### PR TITLE
chore: drop support for `node14`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typescript",
     "type",
     "utitility",
-    "helper",
+    "meta",
     "language",
     "assert",
     "testing"
@@ -23,8 +23,8 @@
   "type": "commonjs",
   "main": "index.js",
   "engines": {
-    "node": "^14.13.1 || >=16.0.0",
-    "npm": ">=8.1.0"
+    "node": ">=16.12.0",
+    "npm": ">=8.10.0"
   },
   "contributors": [
     {


### PR DESCRIPTION
Drop `node14` support and prepare for bumping required version to `node18` depending on feedback and upgrade paths.