### PR TITLE
feat: http

### DIFF
--- a/src/http/header.test.ts
+++ b/src/http/header.test.ts
@@ -1,0 +1,95 @@
+import { ensureHttpHeaderMapping, HttpHeaderMapping, HttpHeaderMappingNormalised, normaliseHttpHeaderKey, normaliseHttpHeaderMapping } from './header';
+
+describe('ensureHttpHeaderMapping()', (): void => {
+  it('with undefined, return empty header object', (): void => {
+    expect(
+      ensureHttpHeaderMapping(undefined),
+    ).toStrictEqual<HttpHeaderMapping>({});
+  });
+
+  it('with null, return empty header object', (): void => {
+    expect(
+      ensureHttpHeaderMapping(null),
+    ).toStrictEqual<HttpHeaderMapping>({});
+  });
+
+  it('with header object, return same header object', (): void => {
+    expect(
+      ensureHttpHeaderMapping({
+        foo: 'bar',
+      }),
+    ).toStrictEqual<HttpHeaderMapping>({
+      foo: 'bar',
+    });
+  });
+});
+
+describe('normaliseHttpHeaderKey()', (): void => {
+  type TestCase = {
+    readonly input: string;
+    readonly expected: Lowercase<string>;
+  };
+
+  it.each<TestCase>([
+    { input: 'CONTENT-TYPE', expected: 'content-type' },
+    { input: 'Content-Type', expected: 'content-type' },
+    { input: 'content-type', expected: 'content-type' },
+  ])('with $input, converts to $expected', (data): void => {
+    expect(
+      normaliseHttpHeaderKey(data.input),
+    ).toStrictEqual<Lowercase<string>>(data.expected)
+  });
+});
+
+describe('normaliseHttpHeaderMapping()', (): void => {
+  it('with header mapping, with upper case keys, normalises', (): void => {
+    type HeaderMapping = {
+      readonly 'CONTENT-TYPE': string;
+      readonly 'CONTENT-LENGTH': string;
+    };
+
+    expect(
+      normaliseHttpHeaderMapping<HeaderMapping>({
+        'CONTENT-TYPE': 'application/json',
+        'CONTENT-LENGTH': '30',
+      }),
+    ).toStrictEqual<HttpHeaderMappingNormalised<HeaderMapping>>({
+      'content-type': 'application/json',
+      'content-length': '30',
+    });
+  });
+
+  it('with header mapping, with pascal case keys, normalises', (): void => {
+    type HeaderMapping = {
+      readonly 'Content-Type': string;
+      readonly 'Content-Length': string;
+    };
+
+    expect(
+      normaliseHttpHeaderMapping<HeaderMapping>({
+        'Content-Type': 'application/json',
+        'Content-Length': '30',
+      }),
+    ).toStrictEqual<HttpHeaderMappingNormalised<HeaderMapping>>({
+      'content-type': 'application/json',
+      'content-length': '30',
+    });
+  });
+
+  it('with header mapping, with lower case keys, does nothing', (): void => {
+    type HeaderMapping = {
+      readonly 'content-type': string;
+      readonly 'content-length': string;
+    };
+
+    expect(
+      normaliseHttpHeaderMapping<HeaderMapping>({
+        'content-type': 'application/json',
+        'content-length': '30',
+      }),
+    ).toStrictEqual<HttpHeaderMappingNormalised<HeaderMapping>>({
+      'content-type': 'application/json',
+      'content-length': '30',
+    });
+  });
+});

--- a/src/http/header.ts
+++ b/src/http/header.ts
@@ -1,0 +1,67 @@
+/**
+ * The representation of a HTTP header key (names).
+ * In all cases a header keys (names) are case-insestive strings.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9110.html#name-header-fields
+ */
+export type HttpHeaderKey = string;
+
+/**
+ * The representation of a HTTP header value.
+ * In all cases a header value is encoded as a string.
+ */
+export type HttpHeaderValue = string;
+
+/**
+ * A mapping of HTTP header values of key {@link Key} (defaulting to string).
+ * In most cases headers cannot be guaranteed so this is considered {@link Partial}.
+ */
+export type HttpHeaderMapping<Key extends HttpHeaderKey = HttpHeaderKey> = Partial<Record<Key, HttpHeaderValue>>;
+
+/**
+ * Ensures the given value is an object that can be used as {@link HttpHeaderMapping}.
+ * If not an empty object is returned, allowing for easier header merges.
+ */
+export const ensureHttpHeaderMapping = <Headers extends HttpHeaderMapping>(value: unknown): Headers => {
+  if (typeof value === 'object' && value !== null) {
+    return value as Headers;
+  }
+
+  return {} as Headers;
+};
+
+/**
+ * Normalise the given {@link HttpHeaderKey} of type {@link Key}.
+ *
+ * This will convert the key's casing to lowercase.
+ */
+export const normaliseHttpHeaderKey = <Key extends HttpHeaderKey>(key: HttpHeaderKey): Lowercase<Key> => {
+  return key.toLowerCase() as Lowercase<Key>;
+};
+
+/**
+ * A normalised {@link HttpHeaderMapping} of type {@link Headers}.
+ *
+ * See {@link normaliseHttpHeaderMapping} for information what normalisation is in this case.
+ * This is just a type that replicates the functionality of that function.
+ */
+export type HttpHeaderMappingNormalised<Headers extends HttpHeaderMapping> = {
+  [K in Lowercase<keyof Headers>]: Headers[K];
+}
+
+/**
+ * Normalise the given {@link HttpHeaderMapping} of type {@link Headers}.
+ *
+ * To normalise a header mapping we convert every key within the mapping to lowercase.
+ * This is because keys are not case sensitive and will allow for a more consistent interaction with header mappings.
+ */
+export const normaliseHttpHeaderMapping = <Headers extends HttpHeaderMapping>(headers: Headers): HttpHeaderMappingNormalised<Headers> => {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => {
+      return [
+        normaliseHttpHeaderKey(key),
+        value,
+      ];
+    }),
+  ) as HttpHeaderMappingNormalised<Headers>;
+};

--- a/src/http/method.test.ts
+++ b/src/http/method.test.ts
@@ -1,0 +1,18 @@
+import { HttpMethod, normaliseHttpMethod } from './method';
+
+describe('normaliseHttpMethod()', (): void => {
+  type TestCase = {
+    readonly input: string;
+    readonly expected: Uppercase<HttpMethod>;
+  };
+
+  it.each<TestCase>([
+    { input: 'delete', expected: 'DELETE' },
+    { input: 'Delete', expected: 'DELETE' },
+    { input: 'DELETE', expected: 'DELETE' },
+  ])('with $input, normalises to $expected', (data): void => {
+    expect(
+      normaliseHttpMethod(data.input as HttpMethod),
+    ).toStrictEqual<Uppercase<HttpMethod>>(data.expected);
+  });
+});

--- a/src/http/method.ts
+++ b/src/http/method.ts
@@ -1,0 +1,31 @@
+export namespace HttpMethod {
+  export type Options = 'OPTIONS';
+  export type Head = 'HEAD';
+  export type Get = 'GET';
+  export type Put = 'PUT';
+  export type Post = 'POST';
+  export type Patch = 'PATCH';
+  export type Delete = 'DELETE';
+}
+
+/**
+ * A union of support HTTP methods.
+ */
+export type HttpMethod = (
+  | HttpMethod.Options
+  | HttpMethod.Head
+  | HttpMethod.Get
+  | HttpMethod.Put
+  | HttpMethod.Post
+  | HttpMethod.Patch
+  | HttpMethod.Delete
+);
+
+/**
+ * Normalise the given {@link HttpHeaderKey} of type {@link Method}.
+ *
+ * This will convert the key's casing to uppercase.
+ */
+export const normaliseHttpMethod = <Method extends HttpMethod>(method: HttpMethod): Uppercase<Method> => {
+  return method.toUpperCase() as Uppercase<Method>;
+};

--- a/src/http/transport.test.ts
+++ b/src/http/transport.test.ts
@@ -1,0 +1,32 @@
+import { createHttpTransport, HttpTransport } from './transport';
+
+describe('createHttpTransport()', (): void => {
+  it('with transport, barebones', (): void => {
+    type Transport = HttpTransport<200, undefined, undefined>;
+
+    expect(
+      createHttpTransport<Transport>({
+        status: 200,
+      }),
+    ).toStrictEqual<Transport>({
+      status: 200,
+      headers: undefined,
+      body: undefined,
+    });
+  });
+
+  it('with transport, with body', (): void => {
+    type Transport = HttpTransport<200, 'something', undefined>;
+
+    expect(
+      createHttpTransport<Transport>({
+        status: 200,
+        body: 'something',
+      }),
+    ).toStrictEqual<Transport>({
+      status: 200,
+      headers: undefined,
+      body: 'something',
+    });
+  });
+});

--- a/src/http/transport.ts
+++ b/src/http/transport.ts
@@ -1,0 +1,79 @@
+import type { Grok, Maybe } from '../index';
+import type { HttpHeaderMapping } from './header';
+
+export type HttpTransportPartStatusCode<Value> = { readonly status: Value };
+export type HttpTransportPartHeaders<Value> = { readonly headers: Value };
+export type HttpTransportPartBody<Value> = { readonly body: Value };
+
+/**
+ * A http response transport data structure.
+ */
+export type HttpTransport<
+  StatusCode extends number,
+  Body = undefined,
+  Headers extends Maybe<HttpHeaderMapping> = Maybe<HttpHeaderMapping>,
+> = (
+  & HttpTransportPartStatusCode<StatusCode>
+  & HttpTransportPartHeaders<Headers>
+  & HttpTransportPartBody<Body>
+);
+
+export type HttpTransportKind = (
+/* eslint-disable @typescript-eslint/indent */
+  HttpTransport<
+    number,
+    any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    any // eslint-disable-line @typescript-eslint/no-explicit-any
+  >
+/* eslint-enable @typescript-eslint/indent */
+);
+
+export type HttpTransportGetStatus<Transport extends HttpTransportKind> = Transport['status'];
+export type HttpTransportGetHeaders<Transport extends HttpTransportKind> = Transport['headers'];
+export type HttpTransportGetBody<Transport extends HttpTransportKind> = Transport['body'];
+
+export type HttpTransportWithStringBody = HttpTransport<number, string>;
+export type HttpTransportWithObjectBody = HttpTransport<number, Grok.Constraint.ObjectLike>;
+
+/**
+ * A smart type that will require only elements of the {@link Transport} that are required.
+ * Where values are typed as `any` or `undefined` the transport item becomes optional.`
+ */
+export type HttpTransportForFactory<Transport extends HttpTransportKind> = (
+  & HttpTransportPartStatusCode<HttpTransportGetStatus<Transport>>
+  & (
+  /* eslint-disable @typescript-eslint/indent */
+    Grok.If<
+      Grok.Or<[
+        Grok.Value.IsAny<HttpTransportGetBody<Transport>>,
+        Grok.Value.IsUndefined<HttpTransportGetBody<Transport>>,
+      ]>,
+      Partial<HttpTransportPartBody<HttpTransportGetBody<Transport>>>,
+      HttpTransportPartBody<HttpTransportGetBody<Transport>>
+    >
+  /* eslint-enable @typescript-eslint/indent */
+  )
+  & (
+  /* eslint-disable @typescript-eslint/indent */
+    Grok.If<
+      Grok.Or<[
+        Grok.Value.IsAny<HttpTransportGetHeaders<Transport>>,
+        Grok.Value.IsUndefined<HttpTransportGetHeaders<Transport>>,
+      ]>,
+      Partial<HttpTransportPartHeaders<HttpTransportGetHeaders<Transport>>>,
+      HttpTransportPartHeaders<HttpTransportGetHeaders<Transport>>
+    >
+  /* eslint-enable @typescript-eslint/indent */
+  )
+);
+
+/**
+ * A factory for creating {@link Transport} from only required elements.
+ */
+export const createHttpTransport = <Transport extends HttpTransportKind>(transport: HttpTransportForFactory<Transport>): Transport => {
+  return {
+    status: transport.status,
+    headers: transport.headers,
+    body: transport.body,
+  } as Transport;
+}


### PR DESCRIPTION
- Introduces `HttpHeader` types and helpers
- Introduces `HttpMethod` types and helpers
- Introduces `HttpTransport` types and helpers for representing HTTP transport layers